### PR TITLE
fix: Fixes charm publishing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,13 +49,6 @@ jobs:
           juju-channel: 3.3/stable
       - name: Run tests using tox
         run: tox -e integration
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v3
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          name: tested-charm
-          path: .tox/**/lego-base-k8s_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm
-          retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
         uses: actions/upload-artifact@v3
@@ -79,12 +72,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
-      - name: Fetch Tested Charm
-        uses: actions/download-artifact@v3
-        with:
-          name: tested-charm
-      - name: Move charm in current directory
-        run: find ./ -name lego-base-k8s_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.4.0
         id: channel


### PR DESCRIPTION
# Description

The CI is failing because the integration tests here don't build the `lego-base-k8s` charm itself. Here we remove the upload/download of the charm and we now build the charm part of the `upload-charm` job.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
