### PR TITLE
fix: observe pebble ready event

### DIFF
--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -95,7 +95,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -124,6 +124,7 @@ class AcmeClient(CharmBase):
             self._on_certificate_creation_request,
         )
         self.framework.observe(self.on.config_changed, self._sync_certificates)
+        self.framework.observe(self.on.pebble_ready, self._sync_certificates)
         self.framework.observe(self.on.update_status, self._sync_certificates)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
         self._plugin = plugin

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -95,7 +95,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -124,9 +124,10 @@ class AcmeClient(CharmBase):
             self._on_certificate_creation_request,
         )
         self.framework.observe(self.on.config_changed, self._sync_certificates)
-        self.framework.observe(self.on.pebble_ready, self._sync_certificates)
         self.framework.observe(self.on.update_status, self._sync_certificates)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
+        pebble_ready_event = getattr(self.on, f'{self._container_name}_pebble_ready')
+        self.framework.observe(pebble_ready_event, self._sync_certificates)
         self._plugin = plugin
 
     def _on_collect_status(self, event: CollectStatusEvent) -> None:


### PR DESCRIPTION
# Description

We observe pebble ready event, making sure we sync certificates and update the charm status when the workload restarts.

This is the first step for fixing:
- https://github.com/canonical/httprequest-lego-k8s-operator/issues/129

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
