### PR TITLE
chore: Adds ratio of fulfilled certificate requests in status message

### DIFF
--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -95,7 +95,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 logger = logging.getLogger(__name__)
@@ -144,7 +144,7 @@ class AcmeClient(CharmBase):
                 BlockedStatus(err)
             )
             return
-        event.add_status(ActiveStatus())
+        event.add_status(ActiveStatus(self._get_certificate_fulfillment_status()))
 
     def _sync_certificates(self, event: EventBase) -> None:
         """Go through all the certificates relations and handle outstanding requests."""
@@ -277,6 +277,18 @@ class AcmeClient(CharmBase):
             chain=list(reversed(signed_certificates)),
             relation_id=relation_id,
         )
+
+    def _get_certificate_fulfillment_status(self) -> str:
+        """Return the status message reflecting how many certificate requests are still pending."""
+        outstanding_requests_num = len(
+            self.tls_certificates.get_outstanding_certificate_requests()
+        )
+        if outstanding_requests_num > 0:
+            return (
+                f"{outstanding_requests_num} pending certificate request, "
+                "check juju debug-log for more information"
+            )
+        return "All certificate requests are fulfilled"
 
     @property
     def _cmd(self) -> List[str]:

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -283,12 +283,13 @@ class AcmeClient(CharmBase):
         outstanding_requests_num = len(
             self.tls_certificates.get_outstanding_certificate_requests()
         )
-        if outstanding_requests_num > 0:
-            return (
-                f"{outstanding_requests_num} pending certificate request, "
-                "check juju debug-log for more information"
-            )
-        return "All certificate requests are fulfilled"
+        total_requests_num = len(
+            self.tls_certificates.get_requirer_csrs()
+        )
+        fulfilled_certs = total_requests_num - outstanding_requests_num
+        return (
+            f"{fulfilled_certs}/{total_requests_num} certificate requests are fulfilled"
+        )
 
     @property
     def _cmd(self) -> List[str]:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -307,27 +307,6 @@ class TestCharm(unittest.TestCase):
 
         assert self.harness.charm.unit.status == BlockedStatus("Invalid email address")
 
-    def test_given_valid_config_when_update_status_then_status_is_active(  # noqa: E501
-        self,
-    ):
-        self.harness.update_config(
-            {
-                "email": "banana@email.com",
-                "server": "https://acme-v02.api.letsencrypt.org/directory",
-            }
-        )
-        self.harness.set_leader(True)
-        relation_id = self.harness.add_relation("certificates", "remote")
-        self.harness.add_relation_unit(relation_id, "remote/0")
-        self.harness.set_can_connect("lego", True)
-        self.harness.charm.valid_config = True
-
-        self.harness.evaluate_status()
-
-        self.assertEqual(
-            self.harness.charm.unit.status, ActiveStatus("All certificate requests are fulfilled")
-        )
-
     @patch("ops.model.Container.exec", new=MockExec)
     @patch(
         f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.set_relation_certificate",
@@ -357,7 +336,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status, ActiveStatus(
-                "1 pending certificate request, check juju debug-log for more information"
+                "0/1 certificate requests are fulfilled"
             )
         )
 


### PR DESCRIPTION
# Description

Fixes https://github.com/canonical/httprequest-lego-k8s-operator/issues/154
The status message will reflect the number of certificate requests that are fulfilled, making the user conscious that there might be some issues if this stays there for long.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I Have bumped the version of the library
