### PR TITLE
feat: introduce proxy related variables

### DIFF
--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -320,15 +320,18 @@ class AcmeClient(CharmBase):
             "run",
         ]
 
+
+
     @property
     def _app_environment(self) -> Dict[str, str]:
         """Extract proxy model environment variables."""
         env = {}
-        if (http_proxy := os.environ.get("HTTP_PROXY", "")):
+
+        if (http_proxy := get_env_var(env_var="HTTP_PROXY")):
             env["HTTP_PROXY"] = http_proxy
-        if (https_proxy := os.environ.get("HTTPS_PROXY", "")):
+        if (https_proxy := get_env_var(env_var="HTTPS_PROXY")):
             env["HTTPS_PROXY"] = https_proxy
-        if(no_proxy := os.environ.get("NO_PROXY", "")):
+        if(no_proxy := get_env_var(env_var="NO_PROXY")):
             env["NO_PROXY"] = no_proxy
         return env
 
@@ -374,3 +377,16 @@ class AcmeClient(CharmBase):
         if not isinstance(server, str):
             return None
         return server
+
+def get_env_var(env_var: str) -> Optional[str]:
+    """Get the environment variable value.
+
+    Looks for all upper-case and all low-case of the `env_var`.
+
+    Args:
+        env_var: Name of the environment variable.
+
+    Returns:
+        Value of the environment variable. None if not found.
+    """
+    return os.environ.get(env_var.upper(), os.environ.get(env_var.lower(), None))

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -331,7 +331,8 @@ class AcmeClient(CharmBase):
             env["HTTP_PROXY"] = http_proxy
         if (https_proxy := get_env_var(env_var="HTTPS_PROXY")):
             env["HTTPS_PROXY"] = https_proxy
-        if(no_proxy := get_env_var(env_var="NO_PROXY")):
+        # there's no need for no_proxy if there's no http_proxy or https_proxy
+        if(no_proxy := get_env_var(env_var="NO_PROXY")) and (http_proxy and https_proxy):
             env["NO_PROXY"] = no_proxy
         return env
 

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -224,7 +224,10 @@ class AcmeClient(CharmBase):
     def _execute_lego_cmd(self) -> bool:
         """Execute lego command in workload container."""
         process = self._container.exec(
-            self._cmd, timeout=300, working_dir="/tmp", environment=self._plugin_config
+            self._cmd,
+            timeout=300,
+            working_dir="/tmp",
+            environment=self._common_config | self._plugin_config,
         )
         try:
             stdout, error = process.wait_output()
@@ -317,6 +320,25 @@ class AcmeClient(CharmBase):
         ]
 
     @property
+    def _common_config(self) -> Dict[str, str]:
+        """Common configuration for the command.
+
+        Used to set the environment context
+
+        Returns:
+            dict[str, str]: common configuration.
+        """
+        common_config = {}
+        if self._http_proxy:
+            common_config["HTTP_PROXY"] = self._http_proxy
+        if self._https_proxy:
+            common_config["HTTPS_PROXY"] = self._https_proxy
+        if self._no_proxy:
+            common_config["NO_PROXY"] = self._no_proxy
+
+        return common_config
+
+    @property
     @abstractmethod
     def _plugin_config(self) -> Dict[str, str]:
         """Plugin specific additional configuration for the command.
@@ -358,3 +380,24 @@ class AcmeClient(CharmBase):
         if not isinstance(server, str):
             return None
         return server
+
+    @property
+    def _http_proxy(self) -> Optional[str]:
+        http_proxy = self.model.config.get("http_proxy", None)
+        if not isinstance(http_proxy, str):
+            return None
+        return http_proxy
+
+    @property
+    def _https_proxy(self) -> Optional[str]:
+        https_proxy = self.model.config.get("https_proxy", None)
+        if not isinstance(https_proxy, str):
+            return None
+        return https_proxy
+
+    @property
+    def _no_proxy(self) -> Optional[str]:
+        no_proxy = self.model.config.get("no_proxy", None)
+        if not isinstance(no_proxy, str):
+            return None
+        return no_proxy

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -327,12 +327,14 @@ class AcmeClient(CharmBase):
         """Extract proxy model environment variables."""
         env = {}
 
-        if (http_proxy := get_env_var(env_var="HTTP_PROXY")):
+        if (http_proxy := get_env_var(env_var="JUJU_CHARM_HTTP_PROXY")):
             env["HTTP_PROXY"] = http_proxy
-        if (https_proxy := get_env_var(env_var="HTTPS_PROXY")):
+        if (https_proxy := get_env_var(env_var="JUJU_CHARM_HTTPS_PROXY")):
             env["HTTPS_PROXY"] = https_proxy
         # there's no need for no_proxy if there's no http_proxy or https_proxy
-        if(no_proxy := get_env_var(env_var="NO_PROXY")) and (http_proxy and https_proxy):
+        if(
+            no_proxy := get_env_var(env_var="JUJU_CHARM_NO_PROXY")
+        ) and (http_proxy and https_proxy):
             env["NO_PROXY"] = no_proxy
         return env
 

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -95,7 +95,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -530,9 +530,9 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Container.exec")
     @patch.dict(
         "os.environ", {
-            "HTTP_PROXY": "Random proxy",
-            "HTTPS_PROXY": "Random https proxy",
-            "NO_PROXY": "No proxy",
+            "JUJU_CHARM_HTTP_PROXY": "Random proxy",
+            "JUJU_CHARM_HTTPS_PROXY": "Random https proxy",
+            "JUJU_CHARM_NO_PROXY": "No proxy",
         }
     )
     @patch(


### PR DESCRIPTION
# Description

Introducing support for HTTP proxying

Golang respects the usage of the environment variables (below) when using HTTP clients:

The following variables are set in the  environment context/shell to constraint the `lego` command
* `HTTP_PROXY`
* `HTTPS_PROXY`
* `NO_PROXY`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I Have bumped the version of the library