### PR TITLE
fix: Remove unnecessary tests and pin pytest-asyncio

### DIFF
--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -97,7 +97,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -253,13 +253,6 @@ class AcmeClient(CharmBase):
             logger.info("Container is not ready")
             return
         csr_subject = self._get_subject_from_csr(csr)
-        if len(csr_subject) > 64:
-            logger.error(
-                "Failed to request certificate, \
-                Subject is too long (> 64 characters): %s",
-                csr_subject,
-            )
-            return
         logger.info("Received Certificate Creation Request for domain %s", csr_subject)
         self._push_csr_to_workload(csr=csr)
         if not self._execute_lego_cmd():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile requirements.in
 #
+annotated-types==0.7.0
+    # via pydantic
 attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
 cffi==1.16.0
     # via cryptography
-cosl==0.0.12
+cosl==0.0.13
     # via -r requirements.in
-cryptography==42.0.8
+cryptography==43.0.0
     # via -r requirements.in
 jsonschema==4.23.0
     # via -r requirements.in
@@ -24,6 +26,10 @@ ops==2.14.1
     #   cosl
 pycparser==2.21
     # via cffi
+pydantic==2.8.2
+    # via cosl
+pydantic-core==2.20.1
+    # via pydantic
 pyyaml==6.0.1
     # via
     #   cosl
@@ -37,6 +43,9 @@ rpds-py==0.18.0
     #   jsonschema
     #   referencing
 typing-extensions==4.10.0
-    # via cosl
+    # via
+    #   cosl
+    #   pydantic
+    #   pydantic-core
 websocket-client==1.7.0
     # via ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ attrs==23.2.0
     #   referencing
 cffi==1.16.0
     # via cryptography
-cosl==0.0.13
+cosl==0.0.14
     # via -r requirements.in
 cryptography==43.0.0
     # via -r requirements.in
@@ -20,11 +20,11 @@ jsonschema==4.23.0
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
-ops==2.14.1
+ops==2.15.0
     # via
     #   -r requirements.in
     #   cosl
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pydantic==2.8.2
     # via cosl
@@ -34,18 +34,18 @@ pyyaml==6.0.1
     # via
     #   cosl
     #   ops
-referencing==0.33.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.18.0
+rpds-py==0.19.0
     # via
     #   jsonschema
     #   referencing
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
     #   cosl
     #   pydantic
     #   pydantic-core
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via ops

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,4 +4,5 @@ juju
 pyright
 pytest
 pytest-operator
+pytest-asyncio==0.21.2
 ruff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,98 +6,103 @@
 #
 asttokens==2.4.1
     # via stack-data
-bcrypt==4.1.2
+bcrypt==4.1.3
     # via paramiko
-cachetools==5.3.3
+cachetools==5.4.0
     # via google-auth
-certifi==2024.2.2
+certifi==2024.7.4
     # via
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-codespell==2.2.6
+codespell==2.3.0
     # via -r test-requirements.in
 coverage[toml]==7.6.0
     # via -r test-requirements.in
 cryptography==43.0.0
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-google-auth==2.28.1
+google-auth==2.32.0
     # via kubernetes
-hvac==2.1.0
+hvac==2.3.0
     # via juju
-idna==3.6
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.22.2
+ipython==8.26.0
     # via ipdb
 jedi==0.19.1
     # via ipython
-jinja2==3.1.3
+jinja2==3.1.4
     # via pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
     #   pytest-operator
-kubernetes==29.0.0
+kubernetes==30.1.0
     # via juju
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
     # via jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
     # via typing-inspect
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via pyright
 oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.2
+packaging==24.1
     # via
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
-parso==0.8.3
+parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via ipython
-protobuf==4.25.3
+protobuf==5.27.2
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via google-auth
-pycparser==2.21
-    # via cffi
-pygments==2.17.2
+pycparser==2.22
+    # via
+    #   -c requirements.txt
+    #   cffi
+pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -117,8 +122,10 @@ pytest==8.3.1
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
-    # via pytest-operator
+pytest-asyncio==0.21.2
+    # via
+    #   -r test-requirements.in
+    #   pytest-operator
 pytest-operator==0.35.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
@@ -127,16 +134,17 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
-requests==2.31.0
+requests==2.32.3
     # via
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
@@ -153,24 +161,26 @@ stack-data==0.6.3
     # via ipython
 toposort==1.10
     # via juju
-traitlets==5.14.1
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.10.0
-    # via typing-inspect
+typing-extensions==4.12.2
+    # via
+    #   -c requirements.txt
+    #   ipython
+    #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.7.0
-    # via kubernetes
+websocket-client==1.8.0
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -24,7 +24,7 @@ codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.6.0
     # via -r test-requirements.in
-cryptography==42.0.8
+cryptography==43.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -78,7 +78,7 @@ parso==0.8.3
     # via jedi
 pexpect==4.9.0
     # via ipython
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
@@ -110,9 +110,9 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.371
+pyright==1.1.372
     # via -r test-requirements.in
-pytest==8.1.2
+pytest==8.3.1
     # via
     #   -r test-requirements.in
     #   pytest-asyncio
@@ -140,7 +140,7 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.5.2
+ruff==0.5.4
     # via -r test-requirements.in
 six==1.16.0
     # via

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -257,34 +257,6 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting to be able to connect to LEGO container"),
         )
 
-    def test_given_subject_name_is_too_long_when_certificate_creation_request_then_message_is_logged(  # noqa: E501
-        self,
-    ):
-        long_subject_names = ["a" * 65, "a" * 66, "a" * 255]
-        self.harness.update_config(
-            {
-                "email": "banana@email.com",
-                "server": "https://acme-v02.api.letsencrypt.org/directory",
-            }
-        )
-        self.harness.set_leader(True)
-        relation_id = self.harness.add_relation("certificates", "remote")
-        self.harness.add_relation_unit(relation_id, "remote/0")
-        self.harness.set_can_connect("lego", True)
-
-        for long_subject_name in long_subject_names:
-            self.add_csr_to_remote_unit_relation_data(
-                relation_id=relation_id, app_or_unit="remote/0", subject=long_subject_name
-            )
-
-            with self.assertLogs(level="ERROR") as log:
-                self.add_csr_to_remote_unit_relation_data(
-                    relation_id=relation_id, app_or_unit="remote/0", subject=long_subject_name
-                )
-                self.assertIn(
-                    f"Subject is too long (> 64 characters): {long_subject_name}", log.output[0]
-                )
-
     def test_given_generic_config_is_not_valid_when_certificate_creation_request_then_status_is_blocked(  # noqa: E501
         self,
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -229,10 +229,7 @@ class TestCharm(unittest.TestCase):
             self.add_csr_to_remote_unit_relation_data(
                 relation_id=relation_id, app_or_unit="remote/0"
             )
-            self.assertIn(
-                "Failed to execute lego command",
-                log.output[1],
-            )
+            assert "Failed to execute lego command" in log.output[1]
 
     def test_given_cannot_connect_to_container_when_certificate_creation_request_then_status_is_waiting(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

#155 by dependabot is failing.
As the cryptography now raises an error (new version 43.0.0) if the subject is too long. That is handled by the tls lib. The check and the test are not needed here anymore

The pinning of `pytest-asyncio` is to handle a a known [issue](https://github.com/pytest-dev/pytest/issues/12269) that happens when `pytest-asyncio==0.21.1` is used with `pytest>8.2.0`. In this PR we pin `pytest-asyncio` to 0.21.2 so unblock dependabot prs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
