### PR TITLE
fix: Fix the check in `relation_created`

### DIFF
--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -103,7 +103,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 
 logger = logging.getLogger(__name__)
@@ -292,7 +292,7 @@ class AcmeClient(CharmBase):
         Args:
             relation_name: Checked relation name
         """
-        return bool(self.model.get_relation(relation_name))
+        return bool(self.model.relations.get(relation_name, []))
 
     @property
     def _cmd(self) -> List[str]:


### PR DESCRIPTION
# Description

If more than one relation is created `get_relations` could raise `TooManyRelatedAppsError`. This change fixes that
Fixes #166 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
