### PR TITLE
build: Use shared workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,40 +14,15 @@ concurrency:
 
 jobs:
   lint-report:
+    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@main
     name: Lint report
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-      - name: Run tests using tox
-        run: tox -e lint
 
   static-analysis:
     name: Static analysis
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-      - name: Run tests using tox
-        run: tox -e static
+    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@main
 
   unit-tests-with-coverage:
-    name: Unit tests
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-      - name: Run tests using tox
-        run: tox -e unit
+    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@main
 
   integration-test-v0:
     name: Integration tests for v0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,15 +14,15 @@ concurrency:
 
 jobs:
   lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@v0
     name: Lint report
 
   static-analysis:
     name: Static analysis
-    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@v0
 
   unit-tests-with-coverage:
-    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@main
+    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@v0
 
   integration-test-v0:
     name: Integration tests for v0


### PR DESCRIPTION
Use shared workflows from https://github.com/canonical/identity-credentials-workflows instead of repeating the same workflows in each project.

This is a first step, and only includes the workflows that were trivial to migrate. More complex workflows that would require parameterization have not been migrated.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
