### PR TITLE
chore: Adds a deprecation notice in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+## Deprecation Notice
+
+**This charm is no longer supported, please consider using [lego-operator](https://github.com/canonical/lego-operator) or [notary-k8s-operator](https://github.com/canonical/notary-k8s-operator) instead.**
+
 # LEGO Base Operator (K8s)
+
 ![CI Status](https://github.com/canonical/lego-base-k8s-operator/actions/workflows/main.yaml/badge.svg)
 [![CharmHub Badge](https://charmhub.io/lego-base-k8s/badge.svg)](https://charmhub.io/lego-base-k8s)
 
@@ -13,9 +18,12 @@ While it is possible to deploy this charm, it is essentially a no-op, and not wh
 The charm should be used to access the `lego_client` library.
 
 To get started using the library, you need to fetch the library using `charmcraft`.
+
 ```shell
 charmcraft fetch-lib charms.lego_base_k8s.v0.lego_client
 ```
+
 You will also need to add the following library to the charm's dependencies:
+
 - jsonschema
 - cryptography

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Deprecation Notice
 
-**This charm is no longer supported, please consider using [lego-operator](https://github.com/canonical/lego-operator) or [notary-k8s-operator](https://github.com/canonical/notary-k8s-operator) instead.**
+**This charm is no longer supported, please use [lego-operator](https://github.com/canonical/lego-operator) instead.**
 
 # LEGO Base Operator (K8s)
 

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -124,7 +124,7 @@ class AcmeClient(CharmBase):
 
     def __init__(self, *args: Any, plugin: str):
         super().__init__(*args)
-        logger.warning("This library is deprecated. Please use lego-operator instead.")
+        logger.warning("This library is deprecated. Please use the lego charm instead.")
         self._csr_path = "/tmp/csr.pem"
         self._certs_path = "/tmp/.lego/certificates/"
         self._container_name = list(self.meta.containers.values())[0].name

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -3,6 +3,8 @@
 
 """# lego_client Library.
 
+Deprication Notice: This library is deprecated. Please use lego-operator instead.
+
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.
 
@@ -103,7 +105,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 
 logger = logging.getLogger(__name__)
@@ -122,6 +124,7 @@ class AcmeClient(CharmBase):
 
     def __init__(self, *args: Any, plugin: str):
         super().__init__(*args)
+        logger.warning("This library is deprecated. Please use lego-operator instead.")
         self._csr_path = "/tmp/csr.pem"
         self._certs_path = "/tmp/.lego/certificates/"
         self._container_name = list(self.meta.containers.values())[0].name

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -3,7 +3,7 @@
 
 """# lego_client Library.
 
-Deprication Notice: This library is deprecated. Please use lego-operator instead.
+Deprecation Notice: This library is deprecated. Please use the lego charm instead: https://charmhub.io/lego.
 
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.

--- a/lib/charms/lego_base_k8s/v1/lego_client.py
+++ b/lib/charms/lego_base_k8s/v1/lego_client.py
@@ -3,7 +3,7 @@
 
 """# lego_client Library.
 
-Deprication Notice: This library is deprecated. Please use lego-operator instead.
+Deprecation Notice: This library is deprecated. Please use the lego charm instead.
 
 
 This library helps user create charms that use LEGO, a letsencrypt client, to provide

--- a/lib/charms/lego_base_k8s/v1/lego_client.py
+++ b/lib/charms/lego_base_k8s/v1/lego_client.py
@@ -3,6 +3,9 @@
 
 """# lego_client Library.
 
+Deprication Notice: This library is deprecated. Please use lego-operator instead.
+
+
 This library helps user create charms that use LEGO, a letsencrypt client, to provide
 certificates to other charms in the charm ecosystem. The certificate requesting functionality
 and the distribution of issued certificates are all done by the Charm class that's provided
@@ -165,7 +168,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 logger = logging.getLogger(__name__)
@@ -184,6 +187,7 @@ class AcmeClient(CharmBase):
 
     def __init__(self, *args: Any, plugin: str):
         super().__init__(*args)
+        logger.warning("This library is deprecated. Please use lego-operator instead.")
         self._logging = LogForwarder(self, relation_name="logging")
         self.tls_certificates = TLSCertificatesProvidesV4(self, CERTIFICATES_RELATION_NAME)
         self.cert_transfer = CertificateTransferProvides(self, CA_TRANSFER_RELATION_NAME)

--- a/lib/charms/lego_base_k8s/v1/lego_client.py
+++ b/lib/charms/lego_base_k8s/v1/lego_client.py
@@ -187,7 +187,7 @@ class AcmeClient(CharmBase):
 
     def __init__(self, *args: Any, plugin: str):
         super().__init__(*args)
-        logger.warning("This library is deprecated. Please use lego-operator instead.")
+        logger.warning("This library is deprecated. Please use the lego charm instead.")
         self._logging = LogForwarder(self, relation_name="logging")
         self.tls_certificates = TLSCertificatesProvidesV4(self, CERTIFICATES_RELATION_NAME)
         self.cert_transfer = CertificateTransferProvides(self, CA_TRANSFER_RELATION_NAME)


### PR DESCRIPTION
# Description

This PR adds a deprecation notice in the README. Once the PR is approved the following will happen:
- Update the description of the repo with the same notice.
- Un-list the charm from Charmhub

**Note**: The same message will be used for the rest of the `lego-k8s` charms that are going to be deprecated.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
